### PR TITLE
*: port basic fuzz from rust-crc32fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
-
-
-
-#Added by cargo
+# Added by cargo
 #
-#already existing elements are commented out
-
+# already existing elements are commented out
 /target
 **/*.rs.bk
 Cargo.lock
 *.exe
 *.pdb
+
+# ignore fuzz elements
+/fuzz/target
+/fuzz/out
+/fuzz/in

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fuzz"
+version = "0.1.0"
+authors = ["The TiKV Project Developers", "Chojan Shang <psiace@outlook.com>"]
+
+[dependencies]
+afl = "0.8.0"
+crc64fast = { path = ".." }

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,6 +1,6 @@
 # Fuzz Testing
 
-This is the fuzz testing target for the crc32fast crate.
+This is the fuzz testing target for the `crc64fast` crate.
 
 1. Install `afl` via `cargo install afl`
 2. Build the fuzz target via `cargo afl build`

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,8 @@
+# Fuzz Testing
+
+This is the fuzz testing target for the crc32fast crate.
+
+1. Install `afl` via `cargo install afl`
+2. Build the fuzz target via `cargo afl build`
+3. Generate a random input file via `head -c 1000 </dev/urandom >in/random`
+4. Run the fuzz test via `cargo afl fuzz -i in -o out -- ./target/debug/fuzz`

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate afl;
+extern crate crc64fast;
+
+use crc64fast::Digest;
+
+fn main() {
+    let digest_init = Digest::new();
+    fuzz!(|data: &[u8]| {
+        let mut digest = digest_init.clone();
+        digest.write(data);
+        digest.sum64();
+    });
+}


### PR DESCRIPTION
Just basic fuzz support, but it’s working fine so far.