### PR TITLE
Refactoring aarch64 simd code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/tikv/crc64fast"
 description = "SIMD accelerated CRC64 calculation"
 exclude = ["build_table.rs"]
 readme = "README.md"
+rust-version = "1.61"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,7 +22,6 @@ criterion = "0.3"
 rand = "0.8"
 
 [features]
-pmull = []
 fake-simd = []
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -38,14 +38,7 @@ be chosen based on CPU feature at runtime.
 
 [crc 1.8.1]: https://crates.io/crates/crc
 
-> **Note:** Since Rust has not stabilized SIMD support on AArch64, you need a
-> nightly compiler and enable the `pmull` feature to use the SIMD-based
-> implementation:
->
-> ```toml
-> [dependencies]
-> crc64fast = { version = "1.0", features = ["pmull"] }
-> ```
+> **Note:** Minimum supported rust version is 1.61
 
 ## TODO
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,6 @@
 //! assert_eq!(checksum, 0x8483_c0fa_3260_7d61);
 //! ```
 
-#![cfg_attr(
-    feature = "pmull",
-    feature(stdsimd, platform_intrinsics, aarch64_target_feature, llvm_asm)
-)]
-
 mod pclmulqdq;
 mod table;
 

--- a/src/pclmulqdq/aarch64.rs
+++ b/src/pclmulqdq/aarch64.rs
@@ -3,7 +3,8 @@
 //! AArch64 implementation of the PCLMULQDQ-based CRC calculation.
 
 use std::arch::aarch64::*;
-use std::mem::transmute;
+use std::arch::asm;
+use std::arch::is_aarch64_feature_detected;
 use std::ops::BitXor;
 
 #[repr(transparent)]
@@ -13,28 +14,28 @@ pub struct Simd(uint8x16_t);
 impl Simd {
     #[inline]
     #[target_feature(enable = "neon")]
-    unsafe fn from_mul(a: poly64_t, b: poly64_t) -> Self {
+    unsafe fn from_mul(a: u64, b: u64) -> Self {
         let mul = vmull_p64(a, b);
         Self(vreinterpretq_u8_p128(mul))
     }
 
     #[inline]
     #[target_feature(enable = "neon")]
-    unsafe fn into_poly64s(self) -> [poly64_t; 2] {
+    unsafe fn into_poly64s(self) -> [u64; 2] {
         let x = vreinterpretq_p64_u8(self.0);
         [vgetq_lane_p64(x, 0), vgetq_lane_p64(x, 1)]
     }
 
     #[inline]
     #[target_feature(enable = "neon")]
-    unsafe fn high_64(self) -> poly64_t {
+    unsafe fn high_64(self) -> u64 {
         let x = vreinterpretq_p64_u8(self.0);
         vgetq_lane_p64(x, 1)
     }
 
     #[inline]
     #[target_feature(enable = "neon")]
-    unsafe fn low_64(self) -> poly64_t {
+    unsafe fn low_64(self) -> u64 {
         let x = vreinterpretq_p64_u8(self.0);
         vgetq_lane_p64(x, 0)
     }
@@ -52,7 +53,7 @@ impl super::SimdExt for Simd {
     }
 
     #[inline]
-    #[target_feature(enable = "crypto", enable = "neon")]
+    #[target_feature(enable = "neon,aes")]
     unsafe fn fold_16(self, coeff: Self) -> Self {
         let h: Self;
         let l: Self;
@@ -60,8 +61,8 @@ impl super::SimdExt for Simd {
         // FIXME: When used as a single function, this branch is equivalent to
         // the ASM below. However, when fold_16 is called inside a loop, for
         // some reason LLVM replaces the PMULL2 call with a plain PMULL, which
-        // leads unnecessary FMOV calls and slows down the throughput from
-        // 20 GiB/s to 14 GiB/s. This bug does not exist with GCC. Delete the
+        // leads unnecessary FMOV calls and slows down the throughput by about
+        // 20-25%. This bug does not exist with GCC. Delete the
         // ASM code once this misoptimization is fixed.
         #[cfg(slow)]
         {
@@ -71,13 +72,20 @@ impl super::SimdExt for Simd {
             l = Self::from_mul(c1, x1);
         }
         #[cfg(not(slow))]
+        #[allow(asm_sub_register)]
         {
-            llvm_asm!(
-                "pmull $0.1q, $2.1d, $3.1d
-                pmull2 $1.1q, $2.2d, $3.2d"
-                : "=&w"(l), "=w"(h)
-                : "w"(self), "w"(coeff)
+            let temp_l: uint8x16_t;
+            let temp_h: uint8x16_t;
+            asm!(
+                "pmull {low}.1q, {in1}.1d, {in2}.1d",
+                "pmull2 {high}.1q, {in1}.2d, {in2}.2d",
+                low = out(vreg) temp_l,
+                high = out(vreg) temp_h,
+                in1 = in(vreg) self.0,
+                in2 = in(vreg) coeff.0,
             );
+            l = Self(temp_l);
+            h = Self(temp_h);
         }
 
         h ^ l
@@ -87,18 +95,18 @@ impl super::SimdExt for Simd {
     #[target_feature(enable = "neon")]
     unsafe fn fold_8(self, coeff: u64) -> Self {
         let [x0, x1] = self.into_poly64s();
-        let h = Self::from_mul(transmute(coeff), x0);
-        let l = Self::new(0, transmute(x1));
+        let h = Self::from_mul(coeff, x0);
+        let l = Self::new(0, x1);
         h ^ l
     }
 
     #[inline]
     #[target_feature(enable = "neon")]
     unsafe fn barrett(self, poly: u64, mu: u64) -> u64 {
-        let t1 = Self::from_mul(self.low_64(), transmute(mu)).low_64();
-        let l = Self::from_mul(t1, transmute(poly));
-        let reduced: u64 = transmute((self ^ l).high_64());
-        let t1: u64 = transmute(t1);
+        let t1 = Self::from_mul(self.low_64(), mu).low_64();
+        let l = Self::from_mul(t1, poly);
+        let reduced: u64 = (self ^ l).high_64();
+        let t1: u64 = t1;
         reduced ^ t1
     }
 }
@@ -109,37 +117,4 @@ impl BitXor for Simd {
     fn bitxor(self, other: Self) -> Self {
         unsafe { Self(veorq_u8(self.0, other.0)) }
     }
-}
-
-//------------------------------------------------------------------------------
-//
-// Below are intrinsics not yet included in Rust.
-
-extern "platform-intrinsic" {
-    fn simd_extract<T, U>(x: T, idx: u32) -> U;
-}
-
-#[inline]
-#[target_feature(enable = "neon")]
-unsafe fn vgetq_lane_p64(a: poly64x2_t, idx: u32) -> poly64_t {
-    let elem: i64 = simd_extract(a, idx);
-    transmute(elem)
-}
-
-#[inline]
-#[target_feature(enable = "neon")]
-unsafe fn vreinterpretq_u8_p128(a: poly128_t) -> uint8x16_t {
-    transmute(a)
-}
-
-#[inline]
-#[target_feature(enable = "neon")]
-unsafe fn vreinterpretq_p64_u8(a: uint8x16_t) -> poly64x2_t {
-    transmute(a)
-}
-
-#[inline]
-#[target_feature(enable = "neon")]
-unsafe fn vcreate_u8(value: u64) -> uint8x8_t {
-    transmute(value)
 }

--- a/src/pclmulqdq/mod.rs
+++ b/src/pclmulqdq/mod.rs
@@ -9,7 +9,7 @@
 
 #[cfg(not(feature = "fake-simd"))]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), path = "x86.rs")]
-#[cfg_attr(all(target_arch = "aarch64", feature = "pmull"), path = "aarch64.rs")]
+#[cfg_attr(all(target_arch = "aarch64"), path = "aarch64.rs")]
 mod arch;
 
 #[cfg(feature = "fake-simd")]
@@ -92,10 +92,7 @@ fn update(mut state: u64, bytes: &[u8]) -> u64 {
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature(enable = "pclmulqdq", enable = "sse2", enable = "sse4.1")
 )]
-#[cfg_attr(
-    all(target_arch = "aarch64", feature = "pmull"),
-    target_feature(enable = "crypto", enable = "neon")
-)]
+#[cfg_attr(all(target_arch = "aarch64"), target_feature(enable = "neon,aes"))]
 unsafe fn update_simd(state: u64, first: &[Simd; 8], rest: &[[Simd; 8]]) -> u64 {
     // receive the initial 128 bytes of data
     let mut x = *first;


### PR DESCRIPTION
Hello,

A lot of aarch64 API's in rust was stabilised by rustc version 1.61 . I have created this PR to refactor aarch64 simd code to use these stable API's  thereby removing the need for nightly compiler.
Also some of the features were removed like llvm_asm in later versions of rust and hence I have replaced that code with asm macro.

The current performance on oracle cloud arm instance looks as below

| variant | throughput |
|---------|--------------|
| CRC64/crc::crc64/16 | 403.60 MiB/s |
| CRC64/crc64fast::table/16 | 2.0431 GiB/s |
| CRC64/crc64fast::simd/16 | 18.297 GiB/s |