### PR TITLE
Implement std::hash::Hasher trait on Digest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
     feature(stdsimd, platform_intrinsics, aarch64_target_feature, llvm_asm)
 )]
 
+use std::hash::Hasher;
+
 mod pclmulqdq;
 mod table;
 
@@ -69,6 +71,16 @@ impl Digest {
 impl Default for Digest {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Hasher for Digest {
+    fn finish(&self) -> u64 {
+        self.sum64()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.write(bytes)
     }
 }
 


### PR DESCRIPTION
This implements the std::hash::Hasher trait on Digest which allows users of the library to use crc64fast in places where std::hash::Hasher is used. While users of this can use the Newtype pattern and implement this themselves, by implementing this trait it makes it more accessible to users of the crate. 